### PR TITLE
Add PWM version reporting API

### DIFF
--- a/Inc/pwm.h
+++ b/Inc/pwm.h
@@ -19,5 +19,6 @@ void Pwm_init(PwmChannel_t* pwm, TIM_HandleTypeDef* htim, uint32_t channel);
 void Pwm_start(PwmChannel_t* pwm);
 void Pwm_stop(PwmChannel_t* pwm);
 void Pwm_setDuty(PwmChannel_t* pwm, uint8_t duty_percent);
+const char* Pwm_getVersion(void);
 
 #endif // PWM_H

--- a/Inc/pwm_version.h
+++ b/Inc/pwm_version.h
@@ -1,0 +1,10 @@
+#ifndef PWM_VERSION_H
+#define PWM_VERSION_H
+
+#define PWM_VERSION_MAJOR 1
+#define PWM_VERSION_MINOR 0
+#define PWM_VERSION_PATCH 0
+
+#define PWM_VERSION_STRING "1.0.0"
+
+#endif // PWM_VERSION_H

--- a/README.md
+++ b/README.md
@@ -12,14 +12,21 @@ A lightweight, reusable STM32 HAL-based PWM control module written in C.
 ## Structure
 - `pwm.h`: Module interface
 - `pwm.c`: Implementation
+- `pwm_version.h`: Version macros
 - `main.c`: Example usage
 
 ## Usage
 Include `pwm.h` and link with STM32 HAL libraries.
-
 Example:
 ```c
 PwmChannel_t pwm;
 Pwm_init(&pwm, &htim3, TIM_CHANNEL_1);
 Pwm_start(&pwm);
 Pwm_setDuty(&pwm, 50); // 50% duty cycle
+```
+
+Include `pwm_version.h` to access version macros. The current version string can
+be obtained with:
+```c
+const char *ver = Pwm_getVersion();
+```

--- a/Src/pwm_version.c
+++ b/Src/pwm_version.c
@@ -1,0 +1,5 @@
+#include "pwm_version.h"
+
+const char* Pwm_getVersion(void) {
+    return PWM_VERSION_STRING;
+}


### PR DESCRIPTION
## Summary
- add `pwm_version.h` defining version macros
- implement `Pwm_getVersion` in new `pwm_version.c`
- expose `Pwm_getVersion` in the public header
- document version header and usage example in README

## Testing
- `gcc -IInc -c Src/pwm_version.c`
- `gcc -IInc -c Src/pwm.c` *(fails: stm32f4xx_hal.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68747a45f76c8323b2d9a1bf75afb5ea