### PR TITLE
Add Makefile and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Build artifacts
+build/
+*.o
+*.out
+*.elf

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# Simple build of example and module
+
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra -IInc
+
+SRCS := $(wildcard Src/*.c) example/main.c
+OBJS := $(SRCS:.c=.o)
+
+# Optionally add logger stub if present
+LOGGER_STUB := logger_stub.c
+ifneq (,$(wildcard $(LOGGER_STUB)))
+SRCS += $(LOGGER_STUB)
+OBJS += $(LOGGER_STUB:.c=.o)
+endif
+
+TARGET := build/main
+
+
+$(TARGET): $(OBJS)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $^ -o $@
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) $(TARGET)
+
+.PHONY: clean

--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ PwmChannel_t pwm;
 Pwm_init(&pwm, &htim3, TIM_CHANNEL_1);
 Pwm_start(&pwm);
 Pwm_setDuty(&pwm, 50); // 50% duty cycle
+```
+
+## Building
+
+A simple `Makefile` is provided to compile the example alongside the module
+sources. Run:
+
+```sh
+make
+```
+
+The resulting binary will be created in the `build/` directory. Use `make clean`
+to remove the generated object files and executable.


### PR DESCRIPTION
## Summary
- add a simple Makefile for building the example
- ignore build artifacts
- document usage of the Makefile in the README

## Testing
- `make` *(fails: missing stm32f4xx_hal.h)*

------
https://chatgpt.com/codex/tasks/task_e_68747a453a5883239ae08bb07713107b