### PR TITLE
Remove logger dependencies from core PWM module

### DIFF
--- a/Inc/pwm.h
+++ b/Inc/pwm.h
@@ -3,7 +3,6 @@
 
 #include "stm32f4xx_hal.h"
 #include <stdint.h>
-#include "logger.h"
 
 /* Module version definitions. These are maintained alongside the
  * implementation so applications do not need to include a separate

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,6 @@ CFLAGS ?= -Wall -Wextra -IInc
 SRCS := $(wildcard Src/*.c) example/main.c
 OBJS := $(SRCS:.c=.o)
 
-# Optionally add logger stub if present
-LOGGER_STUB := logger_stub.c
-ifneq (,$(wildcard $(LOGGER_STUB)))
-SRCS += $(LOGGER_STUB)
-OBJS += $(LOGGER_STUB:.c=.o)
-endif
 
 TARGET := build/main
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ A lightweight, reusable STM32 HAL-based PWM control module written in C.
 - Configurable timer, channel, duty cycle
 - Simple API: `init()`, `start()`, `stop()`, `setDuty()`
 - Suitable for LED dimming, motor control, etc.
-- Optional logger integration for debugging
 - Built-in version query via `Pwm_getVersion()`
 
 ## Structure

--- a/Src/pwm.c
+++ b/Src/pwm.c
@@ -3,8 +3,7 @@
 /*
  * PWM control module implementation. These routines provide a thin
  * abstraction layer over the STM32 HAL to make simple PWM output
- * configuration less error prone. Logging is optional and compiled
- * in only if the user supplies a logger implementation.
+ * configuration less error prone.
  */
 
 /*
@@ -19,21 +18,16 @@ void Pwm_init(PwmChannel_t* pwm, TIM_HandleTypeDef* htim, uint32_t channel) {
     pwm->duty_percent = 0;
 
     HAL_TIM_PWM_Start(pwm->htim, pwm->channel);
-
-    Log(LOG_LEVEL_DEBUG, "PWM initialized on channel %lu (timer: %p, period: %lu)\n",
-        pwm->channel, (void*)pwm->htim, pwm->period);
 }
 
 /* Start PWM signal generation on the configured channel. */
 void Pwm_start(PwmChannel_t* pwm) {
     HAL_TIM_PWM_Start(pwm->htim, pwm->channel);
-    Log(LOG_LEVEL_DEBUG, "PWM started on channel %lu\n", pwm->channel);
 }
 
 /* Stop PWM output on the channel. */
 void Pwm_stop(PwmChannel_t* pwm) {
     HAL_TIM_PWM_Stop(pwm->htim, pwm->channel);
-    Log(LOG_LEVEL_DEBUG, "PWM stopped on channel %lu\n", pwm->channel);
 }
 
 /*
@@ -46,8 +40,6 @@ void Pwm_setDuty(PwmChannel_t* pwm, uint8_t duty_percent) {
 
     uint32_t pulse = (pwm->period * duty_percent) / 100;
     __HAL_TIM_SET_COMPARE(pwm->htim, pwm->channel, pulse);
-
-    Log(LOG_LEVEL_DEBUG, "PWM duty set to %d%% (pulse: %lu)\n", duty_percent, pulse);
 }
 
 /* Report the version string for this module. */

--- a/Src/pwm.c
+++ b/Src/pwm.c
@@ -3,7 +3,7 @@
 /*
  * PWM control module implementation. These routines provide a thin
  * abstraction layer over the STM32 HAL to make simple PWM output
- * configuration less error prone.
+ * configuration easier and less error-prone.
  */
 
 /*

--- a/example/main.c
+++ b/example/main.c
@@ -1,6 +1,5 @@
 #include "stm32f4xx_hal.h"
 #include "pwm.h"
-#include "logger.h"
 
 /*
  * Minimal example demonstrating the PWM module. The HAL initialization
@@ -16,10 +15,9 @@ int main(void) {
     SystemClock_Config(); // Provided elsewhere in your project
     MX_TIM3_Init();       // Provided elsewhere in your project
 
-    Logger_init();
-
-    /* Report driver version via the logger */
-    Log(LOG_LEVEL_INFO, "PWM module version: %s\n", Pwm_getVersion());
+    /* Optionally query driver version */
+    const char* version = Pwm_getVersion();
+    (void)version;
 
     PwmChannel_t pwm;
     Pwm_init(&pwm, &htim3, TIM_CHANNEL_1);

--- a/example/main.c
+++ b/example/main.c
@@ -15,10 +15,6 @@ int main(void) {
     SystemClock_Config(); // Provided elsewhere in your project
     MX_TIM3_Init();       // Provided elsewhere in your project
 
-    /* Optionally query driver version */
-    const char* version = Pwm_getVersion();
-    (void)version;
-
     PwmChannel_t pwm;
     Pwm_init(&pwm, &htim3, TIM_CHANNEL_1);
 


### PR DESCRIPTION
## Summary
- drop logger header include and debug logging from PWM module
- strip example, Makefile, and docs of logger usage

## Testing
- `make clean && make` *(fails: Inc/pwm.h:4:10: fatal error: stm32f4xx_hal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688fc0cf15288323b3cb18f2cc758961