### PR TITLE
feat: support float-based PWM duty cycle

### DIFF
--- a/Inc/pwm.h
+++ b/Inc/pwm.h
@@ -8,10 +8,10 @@
  * implementation so applications do not need to include a separate
  * version header. Bump the numbers whenever the API or behavior
  * changes in a backward-incompatible way. */
-#define PWM_VERSION_MAJOR 1
+#define PWM_VERSION_MAJOR 2
 #define PWM_VERSION_MINOR 0
 #define PWM_VERSION_PATCH 0
-#define PWM_VERSION_STRING "1.0.0"
+#define PWM_VERSION_STRING "2.0.0"
 
 /**
  * @brief Container describing a single PWM output channel.
@@ -24,7 +24,7 @@ typedef struct {
     TIM_HandleTypeDef* htim;  /**< Initialized timer handle controlling the PWM */
     uint32_t channel;         /**< Timer channel (e.g. @ref TIM_CHANNEL_1) */
     uint32_t period;          /**< Timer period (ARR value) used for duty calc */
-    uint8_t duty_percent;     /**< Last duty cycle that was programmed */
+    float duty_percent;       /**< Last duty cycle that was programmed */
 } PwmChannel_t;
 
 /** Initialize a PWM channel instance.
@@ -40,8 +40,8 @@ void Pwm_start(PwmChannel_t* pwm);
 /** Stop PWM signal generation. */
 void Pwm_stop(PwmChannel_t* pwm);
 
-/** Update the duty cycle percentage (0–100%). */
-void Pwm_setDuty(PwmChannel_t* pwm, uint8_t duty_percent);
+/** Update the duty cycle percentage (0.0–100.0). */
+void Pwm_setDuty(PwmChannel_t* pwm, float duty_percent);
 
 /** Obtain the compile-time module version string. */
 const char* Pwm_getVersion(void);

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A lightweight, reusable STM32 HAL-based PWM control module written in C.
 - Simple API: `init()`, `start()`, `stop()`, `setDuty()`
 - Suitable for LED dimming, motor control, etc.
 - Built-in version query via `Pwm_getVersion()`
+- Float-based duty cycle for precise control
 
 ## Structure
 - `pwm.h`: Module interface
@@ -22,5 +23,5 @@ Example:
 PwmChannel_t pwm;
 Pwm_init(&pwm, &htim3, TIM_CHANNEL_1);
 Pwm_start(&pwm);
-Pwm_setDuty(&pwm, 50); // 50% duty cycle
+Pwm_setDuty(&pwm, 50.0f); // 50% duty cycle
 ```

--- a/Src/pwm.c
+++ b/Src/pwm.c
@@ -15,7 +15,7 @@ void Pwm_init(PwmChannel_t* pwm, TIM_HandleTypeDef* htim, uint32_t channel) {
     pwm->htim = htim;
     pwm->channel = channel;
     pwm->period = htim->Init.Period;
-    pwm->duty_percent = 0;
+    pwm->duty_percent = 0.0f;
 
     HAL_TIM_PWM_Start(pwm->htim, pwm->channel);
 }
@@ -34,11 +34,12 @@ void Pwm_stop(PwmChannel_t* pwm) {
  * Update the pulse width to achieve the requested duty cycle. The duty
  * value is clipped to the range 0–100%.
  */
-void Pwm_setDuty(PwmChannel_t* pwm, uint8_t duty_percent) {
-    if (duty_percent > 100) duty_percent = 100;
+void Pwm_setDuty(PwmChannel_t* pwm, float duty_percent) {
+    if (duty_percent > 100.0f) duty_percent = 100.0f;
+    else if (duty_percent < 0.0f) duty_percent = 0.0f;
     pwm->duty_percent = duty_percent;
 
-    uint32_t pulse = (pwm->period * duty_percent) / 100;
+    uint32_t pulse = (uint32_t)((pwm->period * duty_percent) / 100.0f);
     __HAL_TIM_SET_COMPARE(pwm->htim, pwm->channel, pulse);
 }
 

--- a/example/main.c
+++ b/example/main.c
@@ -22,7 +22,7 @@ int main(void) {
 
     /* Sweep duty cycle from 0 to 100% in 10% increments */
     while (1) {
-        for (uint8_t duty = 0; duty <= 100; duty += 10) {
+        for (float duty = 0.0f; duty <= 100.0f; duty += 10.0f) {
             Pwm_setDuty(&pwm, duty);
             HAL_Delay(500);
         }


### PR DESCRIPTION
## Summary
- allow PWM duty cycle to be specified as a float for finer resolution
- bump module version to 2.0.0
- update example and README to demonstrate fractional duty control

## Testing
- `make clean`
- `make` *(fails: stm32f4xx_hal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68976c1ce5108323b8519247a443a9aa